### PR TITLE
fix for large result sets

### DIFF
--- a/lib/QuerySwarm.js
+++ b/lib/QuerySwarm.js
@@ -174,8 +174,11 @@ module.exports = function(redis) {
 							// add tasks to redis queue
 							if(tasks.length > 0) {
 								var params = tasks.slice();
-								params.unshift(self.id + ':queue');
-								multi = multi.lpush.apply(multi, params);
+								while (params.length > 0) {
+									var args = params.splice(0,10000)
+									args.unshift(self.id + ':queue');
+									multi = multi.lpush.apply(multi, args);
+								}
 							}
 
 							multi.exec(function(err) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply

> ... you run the risk of exceeding the JavaScript engine's argument length limit. The consequences of applying a function with too many arguments (think more than tens of thousands of arguments) vary across engines (JavaScriptCore has hard-coded argument limit of 65536), because the limit (indeed even the nature of any excessively-large-stack behavior) is unspecified.

